### PR TITLE
Groups API

### DIFF
--- a/lms/djangoapps/mobile_api/groups/serializers.py
+++ b/lms/djangoapps/mobile_api/groups/serializers.py
@@ -1,0 +1,26 @@
+"""
+Serializer for user API
+"""
+from rest_framework import serializers
+from rest_framework.reverse import reverse
+
+from django.core.validators import RegexValidator
+
+
+class GroupSerializer(serializers.Serializer):
+	"""
+	Serializes facebook groups
+	"""
+	name = serializers.CharField(max_length=150)
+	description = serializers.CharField(max_length=200, required=False)
+	privacy = serializers.ChoiceField(choices=[("open", "open"), ("closed", "closed")], required=False)
+
+class GroupsMembersSerializer(serializers.Serializer): 
+	"""
+	Serializes facebook invitations 
+	"""
+	member_ids = serializers.CharField(	required=True,
+										validators=[RegexValidator(
+								            regex='^([\d]+,?)*$',
+								            message='A comma seperated list of member ids must be provided',
+								            code='member_ids error'),])

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -8,6 +8,8 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from courseware.tests.factories import UserFactory
 
 
+from nose.tools import set_trace
+
 class TestGroups(ModuleStoreTestCase, APITestCase):
     """
     Tests for /api/mobile/v0.5/groups/...
@@ -20,6 +22,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         url = reverse('get-app-groups')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+        set_trace()
         self.assertTrue('groups' in response.data)  # pylint: disable=E1103
 
     def test_create_new_group(self):

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -7,8 +7,10 @@ from rest_framework.test import APITestCase
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from courseware.tests.factories import UserFactory
 
+# TODO: use this for debugging.
 from nose.tools import set_trace
 
+# TODO: keep tests consistent with the regestered Facebook app
 
 class TestGroups(ModuleStoreTestCase, APITestCase):
     """
@@ -123,8 +125,6 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
                                                       'member_id' : member_id}) 
         response = self.client.delete(url)
-
-    # TODO: member doesn't exist, member already in group
 
 
 

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -94,6 +94,12 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 400)
 
+    def test_invite_single_member_malformed_member_id_3(self):
+        group_id = '756869167741019'
+        member_id = '1234,abc,5678'
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 400)
+
     def test_invite_single_member(self):
         group_id = '756869167741019'
         member_id = '10154831816670300'
@@ -101,7 +107,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         # of the group in order to be able to join the group.
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+        self.assertTrue('success' in response.data[member_id])  # pylint: disable=E1103
         # Remove user from the group
         remove_from_group(self, group_id, member_id)
 
@@ -109,8 +115,9 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         member_ids = '366785273488903,939400156088941,10154831816670300'
         group_id = '756869167741019'
         response = invite_to_group(self, group_id, member_ids)
-        self.assertEqual(response.status_code, 200)        
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+        self.assertEqual(response.status_code, 200)
+        for member_id in member_ids.split(','):
+            self.assertTrue('success' in response.data[member_id])  # pylint: disable=E1103
         # Remove the members added
         for member_id in member_ids.split(','):
             remove_from_group(self, group_id, member_id)
@@ -121,11 +128,15 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         group_id = '756869167741019'
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+        self.assertTrue('success' in response.data[member_id])  # pylint: disable=E1103
         # Invite three members, two who are not in the group and one that is a member already.
         member_ids = '366785273488903,939400156088941,10154831816670300'
         response = invite_to_group(self, group_id, member_ids)
-        self.assertEqual(response.status_code, 400)        
+        self.assertEqual(response.status_code, 201)
+        for member_id in '366785273488903,939400156088941'.split(','):
+            self.assertTrue('success' in response.data[member_id])
+        self.assertTrue('(#4001) User is not eligible to be added to group' in response.data['10154831816670300'])
+
         # Remove the members added
         for member_id in member_ids.split(','):
             remove_from_group(self, group_id, member_id)
@@ -137,7 +148,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         # of the group in order to be able to join the group.
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103        
+        self.assertTrue('success' in response.data[member_id])  # pylint: disable=E1103        
         # Remove member
         remove_from_group(self, group_id, member_id)
         

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -9,7 +9,6 @@ from courseware.tests.factories import UserFactory
 
 from nose.tools import set_trace
 
-from nose.tools import set_trace
 
 class TestGroups(ModuleStoreTestCase, APITestCase):
     """
@@ -19,22 +18,21 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.user = UserFactory.create()
         self.client.login(username=self.user.username, password='test')
 
-    def test_get_app_groups(self):
-        # set_trace()
-        url = reverse('get-app-groups')
-        response = self.client.get(url, {'oauth-token' : 'abcd1234'})
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('groups' in response.data)  # pylint: disable=E1103
+    # Deprecated
+    # def test_get_app_groups(self):
+        # url = reverse('get-app-groups')
+        # response = self.client.get(url, {'oauth-token' : 'abcd1234'})
+        # self.assertEqual(response.status_code, 200)
+        # self.assertTrue('groups' in response.data)  # pylint: disable=E1103
 
     def test_create_new_group(self):
         url = reverse('create-new-group') 
-        response = self.client.post(url, {  'name' : 'TheBestGroup', 
+        response = self.client.post(url, {  'name' : 'TheBestGroup2',
                                             'description' : 'The group for the best people',
-                                            'privacy' : 'true',
-                                            'admin-id' : '12345',
-                                            'oauth-token' : 'abcd1234'})
+                                            'privacy' : 'open'})
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('12345' in response.data['group-id'])  # pylint: disable=E1103
+        self.assertTrue('id' in response.data)  # pylint: disable=E1103
+
 
     def test_invite_members(self):
         url = reverse('invite-to-group', kwargs={'group_id':'123456789'}) 
@@ -43,9 +41,10 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('true' in response.data['success'])  # pylint: disable=E1103
 
-    def test_get_all_group_members(self):
-        # set_trace() 
-        url = reverse('members-in-group', kwargs={'group_id':'123456789'})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('members' in response.data)  # pylint: disable=E1103
+    # Deprecated
+    # def test_get_all_group_members(self):
+    #     # set_trace() 
+    #     url = reverse('members-in-group', kwargs={'group_id':'123456789'})
+    #     response = self.client.get(url)
+    #     self.assertEqual(response.status_code, 200)
+    #     self.assertTrue('members' in response.data)  # pylint: disable=E1103

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -114,19 +114,18 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         remove_from_group(self, group_id, member_id)
         
 
-
+# Helper functions
 def delete_group(self, group_id):
     url = reverse('create-delete-group', kwargs={'group_id' : group_id}) 
     response = self.client.delete(url)
     self.assertEqual(response.status_code, 200)
 
 def invite_to_group(self, group_id, member_ids):
-        url = reverse('group-remove-member', kwargs={'group_id' : group_id, 'member_id' : ''}) 
+        url = reverse('add-remove-member', kwargs={'group_id' : group_id, 'member_id' : ''}) 
         return self.client.post(url, {  'member-ids' : member_ids })
 
 def remove_from_group(self, group_id, member_id): 
-    url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
-                                                  'member_id' : member_id}) 
+    url = reverse('add-remove-member', kwargs={ 'group_id' : group_id, 'member_id' : member_id}) 
     response = self.client.delete(url)
     self.assertEqual(response.status_code, 200)
 

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -18,21 +18,25 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.user = UserFactory.create()
         self.client.login(username=self.user.username, password='test')
 
-    # Deprecated
-    # def test_get_app_groups(self):
-        # url = reverse('get-app-groups')
-        # response = self.client.get(url, {'oauth-token' : 'abcd1234'})
-        # self.assertEqual(response.status_code, 200)
-        # self.assertTrue('groups' in response.data)  # pylint: disable=E1103
-
     def test_create_new_group(self):
-        url = reverse('create-new-group') 
-        response = self.client.post(url, {  'name' : 'TheBestGroup2',
+        url = reverse('create-new-group')
+        response = self.client.post(url, {  'name' : 'TheBestGroup',
                                             'description' : 'The group for the best people',
                                             'privacy' : 'open'})
         self.assertEqual(response.status_code, 200)
         self.assertTrue('id' in response.data)  # pylint: disable=E1103
 
+    def test_create_new_group_invalid_params(self):
+        url = reverse('create-new-group')
+        response = self.client.post(url, {  'invalid_param' : 'TheBestGroup'})
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_new_group_no_params(self):
+        url = reverse('create-new-group')
+        set_trace()
+        response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 400)
+        # self.assertTrue('id' in response.data)  # pylint: disable=E1103
 
     def test_invite_members(self):
         url = reverse('invite-to-group', kwargs={'group_id':'123456789'}) 
@@ -40,11 +44,3 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
                                             'oauth-token' : 'abcd1234'})
         self.assertEqual(response.status_code, 200)
         self.assertTrue('true' in response.data['success'])  # pylint: disable=E1103
-
-    # Deprecated
-    # def test_get_all_group_members(self):
-    #     # set_trace() 
-    #     url = reverse('members-in-group', kwargs={'group_id':'123456789'})
-    #     response = self.client.get(url)
-    #     self.assertEqual(response.status_code, 200)
-    #     self.assertTrue('members' in response.data)  # pylint: disable=E1103

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -55,11 +55,9 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
 
         # Remove user from the group
-        url = reverse('group-remove-member', kwargs={ 'group_id' : group_id,
-                                                      'member_id' : member_id}) 
-        response = self.client.delete(url)
+        remove_from_group(self, group_id, member_id)
 
-    
+
     def test_invite_multiple_members_successfully(self):
         member_ids = '366785273488903,939400156088941,10154831816670300'
         group_id = '756869167741019'
@@ -69,9 +67,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
 
         # Remove the members added
         for member_id in member_ids.split(','):
-            url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
-                                                      'member_id' : member_id}) 
-            response = self.client.delete(url)
+            remove_from_group(self, group_id, member_id)
 
 
     def test_invite_multiple_members_unsuccessfully(self):
@@ -89,9 +85,8 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
 
         # Remove the members added
         for member_id in member_ids.split(','):
-            url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
-                                                      'member_id' : member_id}) 
-            response = self.client.delete(url)
+            remove_from_group(self, group_id, member_id)
+
 
     def test_delete_group(self): 
         # Create new group
@@ -116,9 +111,8 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
         
         # Remove member
-        url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
-                                                      'member_id' : member_id}) 
-        response = self.client.delete(url)
+        remove_from_group(self, group_id, member_id)
+        
 
 
 def delete_group(self, group_id):
@@ -130,6 +124,10 @@ def invite_to_group(self, group_id, member_ids):
         url = reverse('group-remove-member', kwargs={'group_id' : group_id, 'member_id' : ''}) 
         return self.client.post(url, {  'member-ids' : member_ids })
 
-
+def remove_from_group(self, group_id, member_id): 
+    url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
+                                                  'member_id' : member_id}) 
+    response = self.client.delete(url)
+    self.assertEqual(response.status_code, 200)
 
 

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -22,7 +22,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
 
     def test_create_new_group(self):
         # Create new group
-        url = reverse('create-new-group')
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {  'name' : 'TheBestGroup',
                                             'description' : 'The group for the best people',
                                             'privacy' : 'open'})
@@ -30,18 +30,17 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.assertTrue('id' in response.data)  # pylint: disable=E1103
         
         # Delete the groupd just created
-        url = reverse('delete-group', kwargs={'group_id' : response.data['id']}) 
-        response = self.client.delete(url)
+        delete_group(self, response.data['id'])        
 
 
     def test_create_new_group_invalid_params(self):
-        url = reverse('create-new-group')
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {  'invalid_param' : 'TheBestGroup'})
         self.assertEqual(response.status_code, 400)
 
 
     def test_create_new_group_no_params(self):
-        url = reverse('create-new-group')
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
 
@@ -51,8 +50,8 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         member_id = '10154831816670300'
         # Note that the memeber must be a member of the app and not a member 
         # of the group in order to be able to join the group.
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
-        response = self.client.post(url, {  'member-ids' : member_id })
+        set_trace()
+        response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
 
@@ -65,8 +64,7 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
     def test_invite_multiple_members_successfully(self):
         member_ids = '366785273488903,939400156088941,10154831816670300'
         group_id = '756869167741019'
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
-        response = self.client.post(url, {  'member-ids' : member_ids })
+        response = invite_to_group(self, group_id, member_ids)
         self.assertEqual(response.status_code, 200)        
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
 
@@ -81,15 +79,13 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         # Add a single user
         member_id = '10154831816670300'
         group_id = '756869167741019'
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
-        response = self.client.post(url, {  'member-ids' : member_id })
+        response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
 
         # Invite three members, two who are not in the group and one that is a member already.
         member_ids = '366785273488903,939400156088941,10154831816670300'
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
-        response = self.client.post(url, {  'member-ids' : member_ids })
+        response = invite_to_group(self, group_id, member_ids)
         self.assertEqual(response.status_code, 400)        
 
         # Remove the members added
@@ -100,31 +96,40 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
 
     def test_delete_group(self): 
         # Create new group
-        url = reverse('create-new-group')
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {  'name' : 'TheBestGroup',
                                             'description' : 'The group for the best people',
                                             'privacy' : 'open'})
         self.assertEqual(response.status_code, 200)
         self.assertTrue('id' in response.data)  # pylint: disable=E1103
         
-        url = reverse('delete-group', kwargs={'group_id' : response.data['id']}) 
-        response = self.client.delete(url)
-        self.assertEqual(response.status_code, 200)
+        # delete group 
+        delete_group(self, response.data['id'])
+
 
     def test_remove_member(self): 
         group_id = '756869167741019'
         member_id = '10154831816670300'
         # Note that the memeber must be a member of the app and not a member 
         # of the group in order to be able to join the group.
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
-        response = self.client.post(url, {  'member-ids' : member_id })
+        response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
         
-        # Remove member 
+        # Remove member
         url = reverse('group-remove-member', kwargs={ 'group_id' : group_id, 
                                                       'member_id' : member_id}) 
         response = self.client.delete(url)
+
+
+def delete_group(self, group_id):
+    url = reverse('create-delete-group', kwargs={'group_id' : group_id}) 
+    response = self.client.delete(url)
+    self.assertEqual(response.status_code, 200)
+
+def invite_to_group(self, group_id, member_ids):
+        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
+        return self.client.post(url, {  'member-ids' : member_ids })
 
 
 

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -50,7 +50,6 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         member_id = '10154831816670300'
         # Note that the memeber must be a member of the app and not a member 
         # of the group in order to be able to join the group.
-        set_trace()
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
@@ -128,7 +127,7 @@ def delete_group(self, group_id):
     self.assertEqual(response.status_code, 200)
 
 def invite_to_group(self, group_id, member_ids):
-        url = reverse('invite-to-group', kwargs={'group_id' : group_id}) 
+        url = reverse('group-remove-member', kwargs={'group_id' : group_id, 'member_id' : ''}) 
         return self.client.post(url, {  'member-ids' : member_ids })
 
 

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -20,7 +20,10 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.user = UserFactory.create()
         self.client.login(username=self.user.username, password='test')
 
-    def test_create_new_group(self):
+    
+    # Group Creation and Deletion Tests
+
+    def test_create_new_open_group(self):
         # Create new group
         url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {  'name' : 'TheBestGroup',
@@ -28,65 +31,35 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
                                             'privacy' : 'open'})
         self.assertEqual(response.status_code, 200)
         self.assertTrue('id' in response.data)  # pylint: disable=E1103
-        
         # Delete the groupd just created
-        delete_group(self, response.data['id'])        
+        delete_group(self, response.data['id'])
 
-
-    def test_create_new_group_invalid_params(self):
+    def test_create_new_closed_group(self):
+        # Create new group
         url = reverse('create-delete-group', kwargs={'group_id' : ''})
-        response = self.client.post(url, {  'invalid_param' : 'TheBestGroup'})
-        self.assertEqual(response.status_code, 400)
+        response = self.client.post(url, {  'name' : 'TheBestGroup',
+                                            'description' : 'The group for the best people',
+                                            'privacy' : 'closed'})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('id' in response.data)  # pylint: disable=E1103
+        # Delete the groupd just created
+        delete_group(self, response.data['id'])
 
-
-    def test_create_new_group_no_params(self):
+    def test_create_new_group_no_name(self):
         url = reverse('create-delete-group', kwargs={'group_id' : ''})
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
 
+    def test_create_new_group_with_invalid_name(self):
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
+        response = self.client.post(url, {  'invalid_name' : 'TheBestGroup'})
+        self.assertEqual(response.status_code, 400)
 
-    def test_invite_single_member(self):
-        group_id = '756869167741019'
-        member_id = '10154831816670300'
-        # Note that the memeber must be a member of the app and not a member 
-        # of the group in order to be able to join the group.
-        response = invite_to_group(self, group_id, member_id)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
-
-        # Remove user from the group
-        remove_from_group(self, group_id, member_id)
-
-
-    def test_invite_multiple_members_successfully(self):
-        member_ids = '366785273488903,939400156088941,10154831816670300'
-        group_id = '756869167741019'
-        response = invite_to_group(self, group_id, member_ids)
-        self.assertEqual(response.status_code, 200)        
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
-
-        # Remove the members added
-        for member_id in member_ids.split(','):
-            remove_from_group(self, group_id, member_id)
-
-
-    def test_invite_multiple_members_unsuccessfully(self):
-        # Add a single user
-        member_id = '10154831816670300'
-        group_id = '756869167741019'
-        response = invite_to_group(self, group_id, member_id)
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue('success' in response.data)  # pylint: disable=E1103
-
-        # Invite three members, two who are not in the group and one that is a member already.
-        member_ids = '366785273488903,939400156088941,10154831816670300'
-        response = invite_to_group(self, group_id, member_ids)
-        self.assertEqual(response.status_code, 400)        
-
-        # Remove the members added
-        for member_id in member_ids.split(','):
-            remove_from_group(self, group_id, member_id)
-
+    def test_create_new_group_with_invalid_privacy(self):
+        url = reverse('create-delete-group', kwargs={'group_id' : ''})
+        response = self.client.post(url, {  'name' : 'TheBestGroup', 
+                                            'privacy' : 'half_open_half_closed'})
+        self.assertEqual(response.status_code, 400)
 
     def test_delete_group(self): 
         # Create new group
@@ -101,7 +74,27 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         delete_group(self, response.data['id'])
 
 
-    def test_remove_member(self): 
+    # Member addition and Removal tests
+
+    def test_invite_single_member_malformed_member_id_1(self):
+        group_id = '756869167741019'
+        member_id = '1234,,,,5678,,'
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 400)
+        
+    def test_invite_single_member_malformed_member_id_2(self):
+        group_id = '756869167741019'
+        member_id = 'this00is00not00a00valid00id'
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 400)
+
+    def test_invite_single_member_no_member_id(self):
+        group_id = '756869167741019'
+        member_id = ''
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 400)
+
+    def test_invite_single_member(self):
         group_id = '756869167741019'
         member_id = '10154831816670300'
         # Note that the memeber must be a member of the app and not a member 
@@ -109,7 +102,42 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         response = invite_to_group(self, group_id, member_id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('success' in response.data)  # pylint: disable=E1103
-        
+        # Remove user from the group
+        remove_from_group(self, group_id, member_id)
+
+    def test_invite_multiple_members_successfully(self):
+        member_ids = '366785273488903,939400156088941,10154831816670300'
+        group_id = '756869167741019'
+        response = invite_to_group(self, group_id, member_ids)
+        self.assertEqual(response.status_code, 200)        
+        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+        # Remove the members added
+        for member_id in member_ids.split(','):
+            remove_from_group(self, group_id, member_id)
+
+    def test_invite_multiple_members_unsuccessfully(self):
+        # Add a single user
+        member_id = '10154831816670300'
+        group_id = '756869167741019'
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+        # Invite three members, two who are not in the group and one that is a member already.
+        member_ids = '366785273488903,939400156088941,10154831816670300'
+        response = invite_to_group(self, group_id, member_ids)
+        self.assertEqual(response.status_code, 400)        
+        # Remove the members added
+        for member_id in member_ids.split(','):
+            remove_from_group(self, group_id, member_id)
+
+    def test_remove_member(self): 
+        group_id = '756869167741019'
+        member_id = '10154831816670300'
+        # Note that the memeber must be a member of the app and not a member 
+        # of the group in order to be able to join the group.
+        response = invite_to_group(self, group_id, member_id)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('success' in response.data)  # pylint: disable=E1103        
         # Remove member
         remove_from_group(self, group_id, member_id)
         
@@ -122,11 +150,9 @@ def delete_group(self, group_id):
 
 def invite_to_group(self, group_id, member_ids):
         url = reverse('add-remove-member', kwargs={'group_id' : group_id, 'member_id' : ''}) 
-        return self.client.post(url, {  'member-ids' : member_ids })
+        return self.client.post(url, {  'member_ids' : member_ids })
 
 def remove_from_group(self, group_id, member_id): 
     url = reverse('add-remove-member', kwargs={ 'group_id' : group_id, 'member_id' : member_id}) 
     response = self.client.delete(url)
     self.assertEqual(response.status_code, 200)
-
-

--- a/lms/djangoapps/mobile_api/groups/tests.py
+++ b/lms/djangoapps/mobile_api/groups/tests.py
@@ -19,28 +19,58 @@ class TestGroups(ModuleStoreTestCase, APITestCase):
         self.client.login(username=self.user.username, password='test')
 
     def test_create_new_group(self):
+        # Create new group
         url = reverse('create-new-group')
         response = self.client.post(url, {  'name' : 'TheBestGroup',
                                             'description' : 'The group for the best people',
                                             'privacy' : 'open'})
         self.assertEqual(response.status_code, 200)
         self.assertTrue('id' in response.data)  # pylint: disable=E1103
+        
+        # Delete the groupd just created
+        url = reverse('delete-group', kwargs={'group_id' : response.data['id']}) 
+        response = self.client.delete(url)
+
 
     def test_create_new_group_invalid_params(self):
         url = reverse('create-new-group')
         response = self.client.post(url, {  'invalid_param' : 'TheBestGroup'})
         self.assertEqual(response.status_code, 400)
 
+
     def test_create_new_group_no_params(self):
         url = reverse('create-new-group')
-        set_trace()
         response = self.client.post(url, {})
         self.assertEqual(response.status_code, 400)
-        # self.assertTrue('id' in response.data)  # pylint: disable=E1103
 
-    def test_invite_members(self):
-        url = reverse('invite-to-group', kwargs={'group_id':'123456789'}) 
-        response = self.client.post(url, {  'member-ids': '1,2,3,4,5,6',
-                                            'oauth-token' : 'abcd1234'})
+
+    def test_invite_single_member(self):
+        url = reverse('invite-to-group', kwargs={'group_id' : '756869167741019'}) 
+        response = self.client.post(url, {  'member-ids' : '10154831816670300' })
         self.assertEqual(response.status_code, 200)
-        self.assertTrue('true' in response.data['success'])  # pylint: disable=E1103
+        set_trace()
+        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+
+    
+    def test_invite_multiple_members(self):
+        set_trace()
+        url = reverse('invite-to-group', kwargs={'group_id' : '756869167741019'}) 
+        response = self.client.post(url, {  'member-ids' : '366785273488903,939400156088941,10154831816670300' })
+        self.assertEqual(response.status_code, 200)        
+        self.assertTrue('success' in response.data)  # pylint: disable=E1103
+
+
+    def test_delete(self): 
+        url = reverse('delete-group', kwargs={'group_id' : '757474821013787'}) 
+        response = self.client.delete(url)
+
+    def test_remove_member(self): 
+        url = reverse('group-remove-member', kwargs={ 'group_id' : '756869167741019', 
+                                                      'member_id' : '10154831816670300'}) 
+        response = self.client.delete(url)
+
+    # TODO: member doesn't exist, memmer already in group
+
+
+
+

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -4,7 +4,7 @@ URLs for groups API
 from django.conf.urls import patterns, url
 from django.conf import settings
 
-from .views import GroupsCreate, GroupsInvite
+from .views import GroupsCreate, GroupsInvite, GroupsDelete, GroupsRemoveMember
 
 urlpatterns = patterns(
     'mobile_api.course_info.views',
@@ -17,5 +17,15 @@ urlpatterns = patterns(
         r'^invite/(?P<group_id>[\d]*)/members$',
         GroupsInvite.as_view(),               
         name='invite-to-group'
+    ), 
+    url(
+        r'^delete/(?P<group_id>[\d]*)$',
+        GroupsDelete.as_view(),               
+        name='delete-group'
+    ),
+    url(
+        r'^delete/(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*)$',
+        GroupsRemoveMember.as_view(),               
+        name='group-remove-member'
     )
 )

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -4,25 +4,20 @@ URLs for groups API
 from django.conf.urls import patterns, url
 from django.conf import settings
 
-from .views import GroupsCreate, GroupsInvite, GroupsDelete, GroupsRemoveMember
+from .views import Groups, GroupsMembers, GroupsRemoveMember
 
 urlpatterns = patterns(
     'mobile_api.course_info.views',
     url(
-        r'^create/$',
-        GroupsCreate.as_view(),               
-        name='create-new-group'
+        r'^create/(?P<group_id>[\d]*)$',
+        Groups.as_view(),               
+        name='create-delete-group'
     ),
     url(
-        r'^invite/(?P<group_id>[\d]*)/members$',
-        GroupsInvite.as_view(),               
+        r'^invite/(?P<group_id>[\d]*)$',
+        GroupsMembers.as_view(),               
         name='invite-to-group'
     ), 
-    url(
-        r'^delete/(?P<group_id>[\d]*)$',
-        GroupsDelete.as_view(),               
-        name='delete-group'
-    ),
     url(
         r'^remove/(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*)$',
         GroupsRemoveMember.as_view(),               

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -24,7 +24,7 @@ urlpatterns = patterns(
         name='delete-group'
     ),
     url(
-        r'^delete/(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*)$',
+        r'^remove/(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*)$',
         GroupsRemoveMember.as_view(),               
         name='group-remove-member'
     )

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -4,7 +4,7 @@ URLs for groups API
 from django.conf.urls import patterns, url
 from django.conf import settings
 
-from .views import Groups, GroupsMembers, GroupsRemoveMember
+from .views import Groups, GroupsMembers
 
 urlpatterns = patterns(
     'mobile_api.course_info.views',
@@ -14,13 +14,8 @@ urlpatterns = patterns(
         name='create-delete-group'
     ),
     url(
-        r'^invite/(?P<group_id>[\d]*)$',
-        GroupsMembers.as_view(),               
-        name='invite-to-group'
-    ), 
-    url(
-        r'^remove/(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*)$',
-        GroupsRemoveMember.as_view(),               
+        r'^member/(?P<group_id>[\d]*)/(?P<member_id>[\d]*,*)$',
+        GroupsMembers.as_view(),
         name='group-remove-member'
     )
 )

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -4,15 +4,10 @@ URLs for groups API
 from django.conf.urls import patterns, url
 from django.conf import settings
 
-from .views import Groups, GroupsCreate, GroupsInvite, GroupsMembers
+from .views import GroupsCreate, GroupsInvite
 
 urlpatterns = patterns(
     'mobile_api.course_info.views',
-    url(
-        r'^$',                        
-        Groups.as_view(),
-        name='get-app-groups'   # TODO: Deprecated
-    ),
     url(
         r'^create/$',
         GroupsCreate.as_view(),               
@@ -22,10 +17,5 @@ urlpatterns = patterns(
         r'^invite/(?P<group_id>[\d]*)/members$',
         GroupsInvite.as_view(),               
         name='invite-to-group'
-    ),
-    url(
-        r'^(?P<group_id>[\d]*)/members$',
-        GroupsMembers.as_view(),
-        name='members-in-group' # TODO: Deprecated
-    ),
+    )
 )

--- a/lms/djangoapps/mobile_api/groups/urls.py
+++ b/lms/djangoapps/mobile_api/groups/urls.py
@@ -9,13 +9,13 @@ from .views import Groups, GroupsMembers
 urlpatterns = patterns(
     'mobile_api.course_info.views',
     url(
-        r'^create/(?P<group_id>[\d]*)$',
-        Groups.as_view(),               
+        r'^(?P<group_id>[\d]*)$',
+        Groups.as_view(),
         name='create-delete-group'
     ),
     url(
-        r'^member/(?P<group_id>[\d]*)/(?P<member_id>[\d]*,*)$',
+        r'^(?P<group_id>[\d]*)/member/(?P<member_id>[\d]*,*)$',
         GroupsMembers.as_view(),
-        name='group-remove-member'
+        name='add-remove-member'
     )
 )

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -6,16 +6,15 @@ from rest_framework import generics, permissions, status
 from rest_framework.authentication import OAuth2Authentication, SessionAuthentication
 from rest_framework.response import Response
 
-import httplib2
-import urllib 
-import facebook     # TODO: talk to lee about dependencies.
+import facebook     # TODO: dependencies to be added to the vagrant 
 
 
 
-# TODO: don't leave this here. 
+# TODO: This should not be in the final commit
 _APP_SECRET = "8a982cfdc0922c9fe57bd63edab6b62f"
 _APP_ID = "734266930001243"
 
+_FACEBOOK_API_VERSION = "/v2.2/"
 from nose.tools import set_trace
 
 
@@ -42,7 +41,7 @@ class GroupsCreate(generics.CreateAPIView):
     
     def create(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        url = "/v2.2/" + _APP_ID + "/groups"
+        url = _FACEBOOK_API_VERSION + _APP_ID + "/groups"
         
         post_args = {}
         for key in request.POST.keys(): 
@@ -83,7 +82,7 @@ class GroupsInvite(generics.CreateAPIView):
     def create(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
         if 'group_id' in kwargs: 
-            url = "/v2.2/" + kwargs['group_id'] + "/members"
+            url = _FACEBOOK_API_VERSION + kwargs['group_id'] + "/members"
         else: 
             return Response({'error' : 'Missing group id'}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -99,7 +98,7 @@ class GroupsInvite(generics.CreateAPIView):
                 except Exception, e:
                     for member_to_remove in successful_additions:
                         post_args = {'member' : member_to_remove, 'method' : 'delete'}
-                        graph.request(url, post_args=post_args) #TODO: assuming that all the deletions happen properly
+                        graph.request(url, post_args=post_args) 
                     return Response({'error' : e.result['error']['message']}, status=status.HTTP_400_BAD_REQUEST)
         return Response({"success" : "true"})
 
@@ -112,7 +111,7 @@ class GroupsDelete(generics.DestroyAPIView):
 
     **Example request**:
 
-        DELETE <app-id>/groups/<group-id>
+        DELETE /groups/<group-id>
 
     **Response Values**
 
@@ -124,7 +123,7 @@ class GroupsDelete(generics.DestroyAPIView):
     def delete(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
         post_args = {'method' : 'delete'}
-        url = "/v2.2/" + _APP_ID + "/groups/" + kwargs['group_id']
+        url = _FACEBOOK_API_VERSION + _APP_ID + "/groups/" + kwargs['group_id']
         result = graph.request(url, post_args=post_args)
         return Response(result)
 
@@ -137,7 +136,7 @@ class GroupsRemoveMember(generics.DestroyAPIView):
 
     **Example request**:
 
-        DELETE <app-id>/groups/<group-id>
+        DELETE /remove/<group-id>/member/<member-id>
 
     **Response Values**
 
@@ -149,7 +148,7 @@ class GroupsRemoveMember(generics.DestroyAPIView):
     def delete(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
         post_args = {'method' : 'delete', 'member' : kwargs['member_id']}
-        url = "/v2.2/" + kwargs['group_id'] + "/members" 
+        url = _FACEBOOK_API_VERSION + kwargs['group_id'] + "/members" 
         result = graph.request(url, post_args=post_args)
         return Response(result)
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -2,84 +2,21 @@
 Views for groups info API
 """
 
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, status
 from rest_framework.authentication import OAuth2Authentication, SessionAuthentication
 from rest_framework.response import Response
 
 import httplib2
 import urllib 
 import facebook     # TODO: talk to lee about dependencies.
-from nose.tools import set_trace
+
+
 
 # TODO: don't leave this here. 
 _APP_SECRET = "8a982cfdc0922c9fe57bd63edab6b62f"
 _APP_ID = "734266930001243"
-_BASE_URL = "https://graph.facebook.com"
 
 from nose.tools import set_trace
-
-class Groups(generics.RetrieveAPIView):
-    """
-    **Use Case**
-
-        An API to support retrival of all the groups related to the edX app that the user is in. 
-
-    **Example request**:
-
-        GET /api/mobile/v0.5/groups
-
-    **Response Values**
-
-        {"groups": [ {  "id": "912988378712053", 
-                            "owner": {  "id": "10154805434030300", 
-                                        "name": "Daniel Eidan"
-                                        }, 
-                            "name": "edX public test1", 
-                            "venue": { "street": ""
-                                        }, 
-                            "privacy": "OPEN", 
-                            "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/y1/r/vF2XT-TEoHq.png", 
-                            "updated_time": "2014-12-03T20:38:32+0000", 
-                            "email": "912988378712053@groups.facebook.com"
-                        } ... 
-                        ]
-            }
-    """
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
-    permission_classes = (permissions.IsAuthenticated,)
-
-    def get(self, request, *args, **kwargs):
-        # Get all the groups associated with the app /734266930001243/groups
-        # Get all the user /me/groups
-        # The intersection of these is the desired response
-
-        # TODO: pass this in as a param 
-        oauth_access_token = "CAACEdEose0cBAMh8IJXYlonj1ZCzvKwCv6v7rKdYlV164ezcuHAqZCig11OlQPRZCvFhG3aBGb78IKIeIhXC1UIZA3DJyNIZCHIZBWNAhF2ymleGNZB92Li4yIO1V19rMZBY3JjbVeIRuAsyzg97hYLi1jJAy4uwjsGG0J2mlCTYtpq9K7nup0xsUpcfIGyco6DxtZBM0BZBNHNtA9sfrfrXwB"
-        graph = facebook.GraphAPI(oauth_access_token)
-        
-        url_user_groups = "/v2.2/me/groups"
-        user_groups_response = graph.request(url_user_groups)
-
-        graph.api_key = facebook.get_app_access_token(_APP_ID, _APP_SECRET)
-        url_app_groups = "/v2.2/" + _APP_ID + "/groups"
-        app_groups_response = graph.request(url_app_groups)
-        
-        # TODO error checking for valid responses
-        return Response({"groups": get_intersection_groups(user_groups_response['data'], app_groups_response['data'])})
-
-def get_intersection_groups(set1, set2): 
-    """ 
-    """
-    # TODO make this fuckin efficient 
-    # set_trace()
-    result_list = []
-    for obj1 in set1: 
-        for obj2 in set2:
-            if obj1['id'] == obj2['id']: 
-                result_list.append(obj1)
-    # set_trace()
-    return result_list
-
 
 
 class GroupsCreate(generics.CreateAPIView):
@@ -91,6 +28,10 @@ class GroupsCreate(generics.CreateAPIView):
     **Example request**:
 
         POST /api/mobile/v0.5/groups/create
+
+        Paramters:  name : string, 
+                    description : string, 
+                    privacy : open/closed
 
     **Response Values**
 
@@ -104,18 +45,12 @@ class GroupsCreate(generics.CreateAPIView):
         url = "/v2.2/" + _APP_ID + "/groups"
         
         post_args = {}
-        if 'name' in request.POST:
-            post_args["name"] = request.POST['name'];
-        if 'description' in request.POST:
-            post_args["description"] = request.POST['description'];
-        if 'privacy' in request.POST:
-            post_args["privacy"] = request.POST['privacy'];
+        for key in request.POST.keys(): 
+            post_args[key] = request.POST[key]
         try:
             app_groups_response = graph.request(url, post_args=post_args)
         except Exception, e:
-            print(e)
-            return e
-
+            return Response({'error' : e.result['error']['message']}, status=status.HTTP_400_BAD_REQUEST)
         return Response(app_groups_response)
 
 
@@ -144,90 +79,4 @@ class GroupsInvite(generics.CreateAPIView):
         return Response(
             {"success": "true"}
         )
-
-
-class GroupsMembers(generics.RetrieveAPIView): 
-    """
-    **Use Case**
-
-        An API to retrive all members of a group
-
-    **Example request**:
-
-        GET /groups/<group-id>/members
-
-
-    **Response Values**
-
-        {   "members":
-                [{
-                    "name": "test",
-                    "id": "12345",
-                },
-                ...
-                ]
-        }
-    """    
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
-    permission_classes = (permissions.IsAuthenticated,)
-
-    def get(self, request, *args, **kwargs):
-        # set_trace()
-        return Response({"members": 
-                            [{  "name": "Daniel Eidan",
-                                "id": "10154831816670300"},
-                            {   "name": "Marc Ashman", 
-                                "id": "10154833899435243"},
-                            {   "name": "Peter Organa", 
-                                "id": "10154805420820176"},
-                            {   "name": "Joey Freund", 
-                                "id": "1279985874"}, 
-                            {   "name": "Yin Zhuoqun", 
-                                "id": "1600206076"},    
-                            {   "name": "David Liu", 
-                                "id": "1658520223"},
-                            {   "name": "Andrew Joe", 
-                                "id": "120401174"}, 
-                            {   "name": "Gaelan D'costa", 
-                                "id": "122600141"}, 
-                            {   "name": "Hafiz Vellani", 
-                                "id": "122609084"}, 
-                            {   "name": "Adir Krafman", 
-                                "id": "500301193"}, 
-                            {   "name": "Naeem Lakhani", 
-                                "id": "502193756"}, 
-                            {   "name": "Alex Mann", 
-                                "id": "502576321"}, 
-                            {   "name": "Natasha Dalal", 
-                                "id": "506753913"}, 
-                            {   "name": "Adam Borzecki", 
-                                "id": "507174319"}, 
-                            {   "name": "Bryant Balatbat", 
-                                "id": "512414329"}, 
-                            {   "name": "Nahim Nasser", 
-                                "id": "516528519"}, 
-                            {   "name": "Farzana Nasser", 
-                                "id": "572710051"}, 
-                            {   "name": "Aaron Ritchie", 
-                                "id": "578710450"}, 
-                            {   "name": "Karthik Ramakrishnan", 
-                                "id": "584467742"}, 
-                            {   "name": "Sinai Gross", 
-                                "id": "591867536"}, 
-                            {   "name": "Ani Tumanyan", 
-                                "id": "617573112"}, 
-                            {   "name": "Paul Jeffrey Crowe", 
-                                "id": "635195067"}, 
-                            {   "name": "Eitan Cohen", 
-                                "id": "657887138"}, 
-                            {   "name": "Eli Atlas", 
-                                "id": "674674636"}, 
-                            {   "name": "Mark Reale", 
-                                "id": "676480219"}]
-                })
-
-
-
-
-
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -15,8 +15,6 @@ _APP_ID = "734266930001243"
 
 _FACEBOOK_API_VERSION = "/v2.2/"
 
-from nose.tools import set_trace
-
 
 class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
     """
@@ -26,7 +24,7 @@ class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
 
     **Creation Example request**:
 
-        POST /api/mobile/v0.5/groups/create
+        POST /api/mobile/v0.5/create/<group_id>
 
         Paramters:  name : string, 
                     description : string, 
@@ -39,7 +37,7 @@ class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
 
     **Deletion Example request**:
         
-        DELETE /groups/<group-id>
+        DELETE /api/mobile/v0.5/create/<group_id>
 
     **Deletion Response Values**
 
@@ -72,20 +70,20 @@ class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
 
 
 
-class GroupsMembers(generics.CreateAPIView):
+class GroupsMembers(generics.CreateAPIView, mixins.DestroyModelMixin):
     """
     **Use Case**
 
-        An API to invite members to a group
+        An API to Invite and Remove members to a group
 
-    **Example request**:
+    **Invite Example request**:
 
-        POST /groups/invite/<group-id>/members
+        POST /api/mobile/v0.5/member/<group_id>/
 
         Parameters: members : int,int,int... 
 
 
-    **Response Values**
+    **Invite Response Values**
 
         {"success" : "true"}        If adding all the member succeeded.
         
@@ -93,6 +91,14 @@ class GroupsMembers(generics.CreateAPIView):
          "member" : "id"}           If one of the members provided can't be added to the group. 
                                     The error message pertains to the first member that couldn't be added.
                                     Note that either all the memebers are added or none at all. 
+
+    **Remove Example request**:
+
+        DELETE /api/mobile/v0.5/member/<group_id>/<member_id>
+
+    **Remove Response Values**
+
+        {"success" : "true"}                                    
     """
     authentication_classes = (OAuth2Authentication, SessionAuthentication)
     permission_classes = (permissions.IsAuthenticated,)
@@ -121,44 +127,13 @@ class GroupsMembers(generics.CreateAPIView):
                     return Response({'error' : e.result['error']['message']}, status=status.HTTP_400_BAD_REQUEST)
         return Response({"success" : "true"})
 
-
-
-class GroupsDelete(generics.DestroyAPIView):
-    """
-    **Use Case**
-
-        An API to delete a group
-
-    **Example request**:
-
-        
-    """
-
-
-
-class GroupsRemoveMember(generics.DestroyAPIView):
-    """
-    **Use Case**
-
-        An API to remove a group member form a group
-
-    **Example request**:
-
-        DELETE /remove/<group-id>/member/<member-id>
-
-    **Response Values**
-
-        {"success" : "true"}
-    """
-    authentication_classes = (OAuth2Authentication, SessionAuthentication)
-    permission_classes = (permissions.IsAuthenticated,)
-
     def delete(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
         post_args = {'method' : 'delete', 'member' : kwargs['member_id']}
         url = _FACEBOOK_API_VERSION + kwargs['group_id'] + "/members" 
         result = graph.request(url, post_args=post_args)
         return Response(result)
+
 
 
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -62,11 +62,14 @@ class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
         return Response(app_groups_response)
 
     def delete(self, request, *args, **kwargs):
-        graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        post_args = {'method' : 'delete'}
-        url = _FACEBOOK_API_VERSION + _APP_ID + "/groups/" + kwargs['group_id']
-        result = graph.request(url, post_args=post_args)
-        return Response(result)
+        if 'group_id' in kwargs:
+            graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
+            post_args = {'method' : 'delete'}
+            url = _FACEBOOK_API_VERSION + _APP_ID + "/groups/" + kwargs['group_id']
+            result = graph.request(url, post_args=post_args)
+            return Response(result)
+        else:
+            return Response({'error' : 'Missing group id'}, status=status.HTTP_400_BAD_REQUEST)
 
 
 
@@ -128,11 +131,17 @@ class GroupsMembers(generics.CreateAPIView, mixins.DestroyModelMixin):
         return Response({"success" : "true"})
 
     def delete(self, request, *args, **kwargs):
-        graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        post_args = {'method' : 'delete', 'member' : kwargs['member_id']}
-        url = _FACEBOOK_API_VERSION + kwargs['group_id'] + "/members" 
-        result = graph.request(url, post_args=post_args)
-        return Response(result)
+        if 'member_id' in kwargs and 'group_id' in kwargs:
+            graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
+            post_args = {'method' : 'delete', 'member' : kwargs['member_id']}
+            url = _FACEBOOK_API_VERSION + kwargs['group_id'] + "/members" 
+            result = graph.request(url, post_args=post_args)
+            return Response(result)
+        if 'member_id' not in kwargs: 
+            return Response({'error' : 'Missing member id'}, status=status.HTTP_400_BAD_REQUEST)
+        else: 
+            return Response({'error' : 'Missing group id'}, status=status.HTTP_400_BAD_REQUEST)
+
 
 
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -132,7 +132,7 @@ class GroupsRemoveMember(generics.DestroyAPIView):
     """
     **Use Case**
 
-        An API to delete a group
+        An API to remove a group member form a group
 
     **Example request**:
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -100,12 +100,23 @@ class GroupsCreate(generics.CreateAPIView):
     permission_classes = (permissions.IsAuthenticated,)
     
     def create(self, request, *args, **kwargs):
-        name = request.POST['name']
-        description = request.POST['description']
-        privacy = request.POST['privacy']
-        admin_id = request.POST['admin-id']
-        oauth_token = request.POST['oauth-token']
-        return Response({"group-id": '12345'})
+        graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
+        url = "/v2.2/" + _APP_ID + "/groups"
+        
+        post_args = {}
+        if 'name' in request.POST:
+            post_args["name"] = request.POST['name'];
+        if 'description' in request.POST:
+            post_args["description"] = request.POST['description'];
+        if 'privacy' in request.POST:
+            post_args["privacy"] = request.POST['privacy'];
+        try:
+            app_groups_response = graph.request(url, post_args=post_args)
+        except Exception, e:
+            print(e)
+            return e
+
+        return Response(app_groups_response)
 
 
 

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -27,7 +27,7 @@ class Groups(generics.CreateAPIView, mixins.DestroyModelMixin):
 
         POST /api/mobile/v0.5/create/<group_id>
 
-        Paramters:  name : string, 
+        Parameters:  name : string, 
                     description : string, 
                     privacy : open/closed
 
@@ -94,7 +94,7 @@ class GroupsMembers(generics.CreateAPIView, mixins.DestroyModelMixin):
 
     **Invite Response Values**
 
-        {"member_id" : success/error_message}       A response with each member_id and wheather or not
+        {"member_id" : success/error_message}       A response with each member_id and whether or not
                                                     the member was added successfully. If the member was 
                                                     not added successfully the Facebook error message is provided. 
         

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -82,7 +82,6 @@ class GroupsInvite(generics.CreateAPIView):
     
     def create(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        set_trace()
         if 'group_id' in kwargs: 
             url = "/v2.2/" + kwargs['group_id'] + "/members"
         else: 
@@ -124,7 +123,6 @@ class GroupsDelete(generics.DestroyAPIView):
 
     def delete(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        set_trace()
         post_args = {'method' : 'delete'}
         url = "/v2.2/" + _APP_ID + "/groups/" + kwargs['group_id']
         result = graph.request(url, post_args=post_args)
@@ -150,7 +148,6 @@ class GroupsRemoveMember(generics.DestroyAPIView):
 
     def delete(self, request, *args, **kwargs):
         graph = facebook.GraphAPI(facebook.get_app_access_token(_APP_ID, _APP_SECRET))
-        set_trace()
         post_args = {'method' : 'delete', 'member' : kwargs['member_id']}
         url = "/v2.2/" + kwargs['group_id'] + "/members" 
         result = graph.request(url, post_args=post_args)

--- a/lms/djangoapps/mobile_api/groups/views.py
+++ b/lms/djangoapps/mobile_api/groups/views.py
@@ -6,9 +6,15 @@ from rest_framework import generics, permissions
 from rest_framework.authentication import OAuth2Authentication, SessionAuthentication
 from rest_framework.response import Response
 
+import httplib2
+import urllib 
+import facebook     # TODO: talk to lee about dependencies.
+from nose.tools import set_trace
 
+# TODO: don't leave this in here
 _APP_SECRET = "8a982cfdc0922c9fe57bd63edab6b62f"
 _APP_ID = "734266930001243"
+_BASE_URL = "https://graph.facebook.com"
 
 class Groups(generics.RetrieveAPIView):
     """
@@ -41,26 +47,54 @@ class Groups(generics.RetrieveAPIView):
     permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):
-        # To get all groups associated with the app /734266930001243/groups
-        # To get all the user /me/groups
+        # Get all the groups associated with the app /734266930001243/groups
+        # Get all the user /me/groups
         # The intersection of these is the desired response
-        return Response(
-            {"groups": [ {  "id": "912988378712053", 
-                            "owner": {  "id": "10154805434030300", 
-                                        "name": "Daniel Eidan"
-                                        }, 
-                            "name": "edX public test1", 
-                            "venue": { "street": ""
-                                        }, 
-                            "privacy": "OPEN", 
-                            "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/y1/r/vF2XT-TEoHq.png", 
-                            "updated_time": "2014-12-03T20:38:32+0000", 
-                            "email": "912988378712053@groups.facebook.com"
-                        }
-                        ]
-            }
-        )
+        
+        # TODO: pass this in as a param 
+        oauth_access_token = "CAAKbz9eIdVsBAJ9B7ZCb8wSrB7KUOvhLHpe3BPZBfL6irMwDgSXA7fZCAmpVg2qsTZCbuX5OZBOdqtKiGakPjR9Tk0bsOeS7uzyU0hzg1xNbne64qoP2dJ7G42apxLsH5A1QZC6Kxav3tWDmJbvd4V5RqDi1noZB8JNwoFtW2mIi2ew6ffoXSAjG672zXlCzfZABZAx8fRsC7S8CxnMXtZAcA7"
+        graph = facebook.GraphAPI(oauth_access_token)
+        
+        url_user_groups = "/v2.2/me/groups"
+        user_groups_response = graph.request(url_user_groups)
 
+        graph.api_key = facebook.get_app_access_token(_APP_ID, _APP_SECRET)
+        url_app_groups = "/v2.2/" + _APP_ID + "/groups"
+        app_groups_response = graph.request(url_app_groups)
+        
+        # TODO error checking for valid responses
+        return Response({"groups": get_intersection_groups(user_groups_response['data'], app_groups_response['data'])})
+
+
+        # return Response(
+        #     {"groups": [ {  "id": "912988378712053", 
+        #                     "owner": {  "id": "10154805434030300", 
+        #                                 "name": "Daniel Eidan"
+        #                                 }, 
+        #                     "name": "edX public test1", 
+        #                     "venue": { "street": ""
+        #                                 }, 
+        #                     "privacy": "OPEN", 
+        #                     "icon": "https://fbstatic-a.akamaihd.net/rsrc.php/v2/y1/r/vF2XT-TEoHq.png", 
+        #                     "updated_time": "2014-12-03T20:38:32+0000", 
+        #                     "email": "912988378712053@groups.facebook.com"
+        #                 }
+        #                 ]
+        #     }
+        # )
+
+def get_intersection_groups(set1, set2): 
+    """ 
+    """
+    # TODO make this fuckin efficient 
+    # set_trace()
+    result_list = []
+    for obj1 in set1: 
+        for obj2 in set2:
+            if obj1['id'] == obj2['id']: 
+                result_list.append(obj1)
+    # set_trace()
+    return result_list
 
 
 class GroupsCreate(generics.CreateAPIView):


### PR DESCRIPTION
# Approvals Required:
- [ ] @NahimNasser (Nahim)


# Stories
1. [MOB- 1120] As a developer I want to support an API end point that proxies creating a game group on Facebook. 
2. [MOB- 1182] As a developer I want to support an API endpoint for adding users to a FB group. 





# Implementation of all API endpoints that relate to Facebook groups functionality. 


        #An API to Create or Delete course groups.

    **Creation Example request**:

        POST /api/mobile/v0.5/create/<group_id>

        Parameters:  name : string, 
                    description : string, 
                    privacy : open/closed

    **Creation Response Values**

        {"group-id": group_id}
    

    **Deletion Example request**:
        
        DELETE /api/mobile/v0.5/create/<group_id>

    **Deletion Response Values**

        {"success" : "true"}




        #An API to Invite and Remove members to a group

    **Invite Example request**:

        POST /api/mobile/v0.5/member/<group_id>/

        Parameters: members : int,int,int... 


    **Invite Response Values**

        {"member_id" : success/error_message}       A response with each member_id and whether or not
                                                    the member was added successfully. If the member was 
                                                    not added successfully the Facebook error message is provided. 
        
    **Remove Example request**:

        DELETE /api/mobile/v0.5/member/<group_id>/<member_id>

    **Remove Response Values**

        {"success" : "true"} 